### PR TITLE
casted int naa_q and naa_t into double in order to make sqrt work fine

### DIFF
--- a/src/main_align.c
+++ b/src/main_align.c
@@ -84,7 +84,7 @@ void main_align(void) {
   }
 
   /**  naa effective (for Dali Zscore)  **/
-  input.naa_eff = sqrt(naa_q * naa_t);
+  input.naa_eff = sqrt((double)naa_q * (double)naa_t);
 
   /**  calloc RESDAT  **/
   resdat_q = (RESDAT *)calloc((size_t)(naa_q + 1), sizeof(RESDAT));


### PR DESCRIPTION
sqrtに直接intを渡していて問題がありそうだったのでdoubleにキャストするよう修正しました

Definition of input.naa_eff in main_align.c was changed from
` input.naa_eff = sqrt(naa_q * naa_t) ;`
to
` input.naa_eff = sqrt((double)naa_q * (double)naa_t) ;`
so that sqrt function works fine without implicit type conversion.